### PR TITLE
Add QHM release command

### DIFF
--- a/scripts/qhm.coffee
+++ b/scripts/qhm.coffee
@@ -79,7 +79,7 @@ module.exports = (robot) ->
 
   releaseQHM = (msg) ->
     return msg.send "利用できません" unless process.env.ENSMALL_HOOK_URL and process.env.ENSMALL_TOKEN
-    return msg.send "#dev でお願いします" unless msg.envelope.user.room in ["dev", "Shell"]
+    return msg.send "#dev でお願いします" unless msg.envelope.user.room in ["dev", "hubot", "Shell"]
 
     url = process.env.ENSMALL_HOOK_URL + "/release"
     data =


### PR DESCRIPTION
## 概要
- qhm:release コマンドを追加
- 「hubot QHMをリリースしてー」と語りかけてもOK
- hokuken/qhmpro の master を ensmall.net 内のインストールシステム用にリリースする
- #dev #hubot 内でのみ実行可能
- sinatra の webhook システム `http://ensmall.net:5678` に依存する
## 技術的要件
- GitHub にならい、リクエストヘッダーに `X-Hub-Signature` を含める
- `X-Hub-Signature` は HMAC を用いたハッシュ [gist](https://gist.github.com/big2men/621ab0ac2dffa6d5bbfa)
- `User-Agent` ヘッダーは `Hokuken-Hubot/{version}` e.g. `Hokuken-Hubot/1.1.1`
