### PR TITLE
Fix filename

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -1,1 +1,1 @@
-["redis-brain.coffee", "shipit.coffee", "helpscout.coffee", "github-pull-request-notifier"]
+["redis-brain.coffee", "shipit.coffee", "helpscout.coffee", "github-pull-request-notifier.coffee"]


### PR DESCRIPTION
hubot-scripts を使う場合、必ず拡張子を指定する

NG: `script-name`
OK: `script-name.coffee`
