### PR TITLE
Bump up hubot-slack version to v3.[ci skip]

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cson": "^1.6.1",
     "hubot": ">= 2.6.0 < 3.0.0",
     "hubot-scripts": ">= 2.5.0 < 3.0.0",
-    "hubot-slack": "^2.1.0",
+    "hubot-slack": "^3.3.0",
     "moment": "^2.8.3",
     "numeral": "^1.5.3",
     "quiche": "0.0.8",


### PR DESCRIPTION
## 参考

- hubot-slack3.xがいつの間にかプライベートチャンネル対応してたので設定メモ
<http://qiita.com/toritori0318/items/e5cef2666d36214b229d>

- SlackのHubot Integrationが知らぬ間にアップデートされてた
<http://qiita.com/KeitaMoromizato/items/0ee11d795d18a49538d8>

- hubot-slack README.md
<https://github.com/slackhq/hubot-slack/blob/master/README.md>


## 概要

- hubot-slackのバージョンを3にあげた

## 補足

@big2men 
hubot-slackのバージョンを3以上にすると、
hubotをチャンネルにinviteする形式になるらしく、
プライベートチャンネルでもhubotが動作するようになるみたいです。

どうでしょうか？


## TODO

- [x] 新しいhubot integrationをslackに作る
- [x] `HUBOT_SLACK_TOKEN`を更新する
- [x] 他の`HUBOT_SLACK_*`環境変数を削除する
- [x] デプロイする