### PR TITLE
Fix net

### DIFF
--- a/scripts/net.coffee
+++ b/scripts/net.coffee
@@ -47,7 +47,6 @@ module.exports = (robot) ->
                 value: domain
                 short: true
               }
-          # post message, attachment
           data = {
             channel:     "#" + msg.envelope.user.room
             attachments: [attachment]
@@ -71,14 +70,3 @@ module.exports = (robot) ->
           unless err
             result.domains = domains
           callback.call robot, result
-
-  post = (message, attachments...) ->
-    robot.logger.info "Post to hubot hook via net script"
-
-    path = "/services/hooks/hubot"
-    data =
-      username: robot.name
-      channel: message.room
-      attachments: attachments
-
-    robot.adapter.post? path, JSON.stringify data

--- a/scripts/net.coffee
+++ b/scripts/net.coffee
@@ -24,6 +24,9 @@ module.exports = (robot) ->
         text = "IP: #{result.address}\n"
         text += "Domains:\n" + result.domains.join("\n") if result.domains?
 
+        msg.send text
+        return
+
         if robot.adapterName is "slack"
           message = {room: "#" + msg.envelope.user.room}
           attachment = {

--- a/scripts/net.coffee
+++ b/scripts/net.coffee
@@ -24,11 +24,7 @@ module.exports = (robot) ->
         text = "IP: #{result.address}\n"
         text += "Domains:\n" + result.domains.join("\n") if result.domains?
 
-        msg.send text
-        return
-
         if robot.adapterName is "slack"
-          message = {room: "#" + msg.envelope.user.room}
           attachment = {
             pretext: "*#{host}*"
             fallback: text
@@ -51,7 +47,15 @@ module.exports = (robot) ->
                 value: domain
                 short: true
               }
-          post message, attachment
+          # post message, attachment
+          data = {
+            channel:     "#" + msg.envelope.user.room
+            text:        text
+            attachments: [attachment]
+          }
+
+          robot.emit "slack.attachment", data
+
 
         else
           msg.send text

--- a/scripts/net.coffee
+++ b/scripts/net.coffee
@@ -50,7 +50,6 @@ module.exports = (robot) ->
           # post message, attachment
           data = {
             channel:     "#" + msg.envelope.user.room
-            text:        text
             attachments: [attachment]
           }
 


### PR DESCRIPTION
## 概要

カスタムメッセージの投稿処理を新しい hubot-slack に合わせて書き直した。
## カスタムメッセージを投稿するには

``` coffeescript
attachment = { ... }
data = {
  channel: "#" + msg.envelope.user.room # 宛先
  text: "..." # メッセージ内容。 attachments があるなら無くてもよい
  attachments: [attachment] # カスタム投稿のリスト
}
robot.emit "slack.attachment", data
```
## Attachments 仕様

[API ドキュメント](https://api.slack.com/docs/attachments)
